### PR TITLE
Expand on trace

### DIFF
--- a/changes/9022.extract_1d.rst
+++ b/changes/9022.extract_1d.rst
@@ -1,2 +1,2 @@
 Expanded the ``use_source_posn`` option to calculate a source trace from WCS and expected source positions for unresampled NIRSpec and MIRI LRS fixed slit data.
-Added the step parameter ``trace_offset`` to allow an additional aperture offset in pixels.
+Added the step parameter ``position_offset`` to allow an additional aperture offset in pixels.

--- a/changes/9022.extract_1d.rst
+++ b/changes/9022.extract_1d.rst
@@ -1,1 +1,2 @@
-Added on option to calculate a source trace from WCS and expected source positions for NIRSpec BOTS/MOS/FS data and perform a box extraction around that trace.  This option is turned on by default for the BOTS mode.
+Expanded the ``use_source_posn`` option to calculate a source trace from WCS and expected source positions for unresampled NIRSpec and MIRI LRS fixed slit data.
+Added the step parameter ``trace_offset`` to allow an additional aperture offset in pixels.

--- a/docs/jwst/extract_1d/arguments.rst
+++ b/docs/jwst/extract_1d/arguments.rst
@@ -30,7 +30,7 @@ Step Arguments for Slit and Slitless Spectroscopic Data
   Set to False to ignore position estimates for all modes; set to True to additionally attempt
   source position correction for extended sources.
 
-``--trace_offset``
+``--position_offset``
   Specify a number of pixels (fractional pixels are allowed) to offset the 
   extraction aperture from the nominal position.  The default is 0.
 

--- a/docs/jwst/extract_1d/arguments.rst
+++ b/docs/jwst/extract_1d/arguments.rst
@@ -26,21 +26,13 @@ Step Arguments for Slit and Slitless Spectroscopic Data
   file should be shifted to account for the expected position of the source. If None (the default),
   the step will decide whether to use the source position based
   on the observing mode and the source type. By default, source position corrections
-  are attempted only for NIRSpec MOS and NIRSpec and MIRI LRS fixed-slit point sources.
+  are attempted only for point sources in NIRSpec MOS/FS/BOTS and MIRI LRS fixed-slit exposures.
   Set to False to ignore position estimates for all modes; set to True to additionally attempt
-  source position correction for NIRSpec BOTS data or extended sources.
-
-``--use_trace``
-  Specify whether to calculate a 2D trace and extract the pixels around that trace
-  within the ``extract_width`` defined in the :ref:`EXTRACT1D <extract1d_reffile>`.
-  If None (the default), the step will decide whether to use the source position based
-  on the observing mode.  Currently this option is only available for NIRSpec BOTS, MOS,
-  and fixed-slit modes, where the trace will be calculated from the expected positions 
-  of the sources.  This option is used by default for the NIRSpec BOTS mode.
+  source position correction for extended sources.
 
 ``--trace_offset``
   Specify a number of pixels (fractional pixels are allowed) to offset the 
-  calculated trace if ``use_trace`` is set to True.  The default is 0.
+  extraction aperture from the nominal position.  The default is 0.
 
 ``--smoothing_length``
   If ``smoothing_length`` is greater than 1 (and is an odd integer), the

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -31,6 +31,9 @@ log.setLevel(logging.DEBUG)
 WFSS_EXPTYPES = ['NIS_WFSS', 'NRC_WFSS', 'NRC_GRISM']
 """Exposure types to be regarded as wide-field slitless spectroscopy."""
 
+SRCPOS_EXPTYPES = ['MIR_LRS-FIXEDSLIT', 'NRS_FIXEDSLIT', 'NRS_MSASPEC', 'NRS_BRIGHTOBJ']
+"""Exposure types for which source position can be estimated."""
+
 ANY = "ANY"
 """Wildcard for slit name.
 
@@ -315,7 +318,7 @@ def get_extract_parameters(ref_dict, input_model, slitname, sp_order, meta,
                     if use_source_posn is None:  # no value set on command line
                         if use_source_posn_aper is None:  # no value set in ref file
                             # Use a suitable default
-                            if meta.exposure.type in ['MIR_LRS-FIXEDSLIT', 'NRS_FIXEDSLIT', 'NRS_MSASPEC']:
+                            if meta.exposure.type in SRCPOS_EXPTYPES:
                                 use_source_posn = True
                                 log.info(f"Turning on source position correction "
                                          f"for exp_type = {meta.exposure.type}")
@@ -1018,11 +1021,11 @@ def location_from_wcs(input_model, slit):
         location.
     """
     if slit is not None:
-        shape = slit.data.shape
+        shape = slit.data.shape[-2:]
         wcs = slit.meta.wcs
         dispaxis = slit.meta.wcsinfo.dispersion_direction
     else:
-        shape = input_model.data.shape
+        shape = input_model.data.shape[-2:]
         wcs = input_model.meta.wcs
         dispaxis = input_model.meta.wcsinfo.dispersion_direction
 

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -146,7 +146,7 @@ def read_apcorr_ref(refname, exptype):
 def get_extract_parameters(ref_dict, input_model, slitname, sp_order, meta,
                            smoothing_length=None, bkg_fit=None, bkg_order=None,
                            use_source_posn=None, subtract_background=None,
-                           trace_offset=0.0):
+                           position_offset=0.0):
     """Get extraction parameter values.
 
     Parameters
@@ -209,7 +209,7 @@ def get_extract_parameters(ref_dict, input_model, slitname, sp_order, meta,
     subtract_background : bool or None, optional
         If False, all background parameters will be ignored.
 
-    trace_offset : float or None, optional
+    position_offset : float or None, optional
         Pixel offset to apply to the nominal source location.
         If None, the value specified in `ref_dict` will be used or it
         will default to 0.
@@ -243,7 +243,7 @@ def get_extract_parameters(ref_dict, input_model, slitname, sp_order, meta,
         extract_params['use_source_posn'] = False  # no source position correction
         extract_params['position_correction'] = 0
         extract_params['independent_var'] = 'pixel'
-        extract_params['trace_offset'] = 0.
+        extract_params['position_offset'] = 0.
         extract_params['trace'] = None
         # Note that extract_params['dispaxis'] is not assigned.
         # This will be done later, possibly slit by slit.
@@ -327,7 +327,7 @@ def get_extract_parameters(ref_dict, input_model, slitname, sp_order, meta,
                         else:  # use the value from the ref file
                             use_source_posn = use_source_posn_aper
                     extract_params['use_source_posn'] = use_source_posn
-                    extract_params['trace_offset'] = trace_offset
+                    extract_params['position_offset'] = position_offset
                     extract_params['trace'] = None
 
                     extract_params['extract_width'] = aper.get('extract_width')
@@ -1365,8 +1365,8 @@ def define_aperture(input_model, slit, extract_params, exp_type):
     # Store the trace, if computed
     extract_params['trace'] = trace
 
-    # Add an extra position offset if desired, from extract_params['trace_offset']
-    offset = extract_params.get('trace_offset', 0.0)
+    # Add an extra position offset if desired, from extract_params['position_offset']
+    offset = extract_params.get('position_offset', 0.0)
     if offset != 0.0:
         log.info(f"Applying additional cross-dispersion offset {offset:.2f} pixels")
         shift_by_offset(offset, extract_params, update_trace=True)
@@ -1970,7 +1970,7 @@ def create_extraction(input_model, slit, output_model,
 def run_extract1d(input_model, extract_ref_name="N/A", apcorr_ref_name=None,
                   smoothing_length=None, bkg_fit=None, bkg_order=None,
                   log_increment=50, subtract_background=None,
-                  use_source_posn=None, trace_offset=0.0,
+                  use_source_posn=None, position_offset=0.0,
                   save_profile=False, save_scene_model=False):
     """Extract all 1-D spectra from an input model.
 
@@ -2006,7 +2006,7 @@ def run_extract1d(input_model, extract_ref_name="N/A", apcorr_ref_name=None,
         If True, the target and background positions specified in the
         reference file (or the default position, if there is no reference
         file) will be shifted to account for source position offset.
-    trace_offset : float
+    position_offset : float
         Number of pixels to shift the nominal source position in the
         cross-dispersion direction.
     save_profile : bool
@@ -2106,7 +2106,7 @@ def run_extract1d(input_model, extract_ref_name="N/A", apcorr_ref_name=None,
                    bkg_fit=bkg_fit, bkg_order=bkg_order,
                    subtract_background=subtract_background,
                    use_source_posn=use_source_posn,
-                   trace_offset=trace_offset)
+                   position_offset=position_offset)
             except ContinueError:
                 continue
 
@@ -2143,7 +2143,7 @@ def run_extract1d(input_model, extract_ref_name="N/A", apcorr_ref_name=None,
                         bkg_fit=bkg_fit, bkg_order=bkg_order,
                         subtract_background=subtract_background,
                         use_source_posn=use_source_posn,
-                        trace_offset=trace_offset)
+                        position_offset=position_offset)
                 except ContinueError:
                     pass
 
@@ -2182,7 +2182,7 @@ def run_extract1d(input_model, extract_ref_name="N/A", apcorr_ref_name=None,
                         bkg_fit=bkg_fit, bkg_order=bkg_order,
                         subtract_background=subtract_background,
                         use_source_posn=use_source_posn,
-                        trace_offset=trace_offset)
+                        position_offset=position_offset)
                 except ContinueError:
                     pass
 

--- a/jwst/extract_1d/extract.py
+++ b/jwst/extract_1d/extract.py
@@ -797,8 +797,8 @@ def box_profile(shape, extract_params, wl_array, coefficients='src_coeff',
 
     # Set aperture region, in this priority order:
     # 1. src_coeff upper and lower limits (or bkg_coeff, for background profile)
-    # 2. Using a trace +/- the extraction width
-    # 3. center of start/stop values +/- extraction width
+    # 2. trace +/- extraction width / 2
+    # 3. center of start/stop values +/- extraction width / 2
     # 4. start/stop values
     profile = np.full(shape, 0.0)
     if extract_params[coefficients] is not None:

--- a/jwst/extract_1d/extract_1d_step.py
+++ b/jwst/extract_1d/extract_1d_step.py
@@ -162,7 +162,6 @@ class Extract1dStep(Step):
     apply_apcorr = boolean(default=True)  # apply aperture corrections?
 
     use_source_posn = boolean(default=None)  # use source coords to center extractions?
-    use_trace = boolean(default=None)  # use source trace for extraction
     trace_offset = float(default=0)  # number of pixels to shift source trace in the cross-dispersion direction
     smoothing_length = integer(default=None)  # background smoothing size
     bkg_fit = option("poly", "mean", "median", None, default=None)  # background fitting type
@@ -424,7 +423,6 @@ class Extract1dStep(Step):
                         self.log_increment,
                         self.subtract_background,
                         self.use_source_posn,
-                        self.use_trace,
                         self.trace_offset,
                         self.save_profile,
                         self.save_scene_model,

--- a/jwst/extract_1d/extract_1d_step.py
+++ b/jwst/extract_1d/extract_1d_step.py
@@ -162,7 +162,7 @@ class Extract1dStep(Step):
     apply_apcorr = boolean(default=True)  # apply aperture corrections?
 
     use_source_posn = boolean(default=None)  # use source coords to center extractions?
-    trace_offset = float(default=0)  # number of pixels to shift source trace in the cross-dispersion direction
+    position_offset = float(default=0)  # number of pixels to shift source trace in the cross-dispersion direction
     smoothing_length = integer(default=None)  # background smoothing size
     bkg_fit = option("poly", "mean", "median", None, default=None)  # background fitting type
     bkg_order = integer(default=None, min=0)  # order of background polynomial fit
@@ -423,7 +423,7 @@ class Extract1dStep(Step):
                         self.log_increment,
                         self.subtract_background,
                         self.use_source_posn,
-                        self.trace_offset,
+                        self.position_offset,
                         self.save_profile,
                         self.save_scene_model,
                     )

--- a/jwst/extract_1d/tests/conftest.py
+++ b/jwst/extract_1d/tests/conftest.py
@@ -34,9 +34,24 @@ def simple_wcs():
     # Add a bounding box
     simple_wcs_function.bounding_box = wcs_bbox_from_shape(shape)
 
-    # Add a few expected attributes, so they can be monkeypatched as needed
-    simple_wcs_function.get_transform = None
-    simple_wcs_function.backward_transform = None
+    # Define a simple transform
+    def get_transform(*args, **kwargs):
+        def return_results(*args, **kwargs):
+            if len(args) == 2:
+                zeros = np.zeros(args[0].shape)
+                wave, _ = np.meshgrid(args[0], args[1])
+                return zeros, zeros, wave
+            if len(args) == 3:
+                try:
+                    nx = len(args[0])
+                except TypeError:
+                    nx = 1
+                pix = np.arange(nx)
+                trace = np.ones(nx)
+                return pix, trace
+        return return_results
+
+    simple_wcs_function.get_transform = get_transform
     simple_wcs_function.available_frames = []
 
     return simple_wcs_function
@@ -68,10 +83,17 @@ def simple_wcs_transpose():
     # Add a bounding box
     simple_wcs_function.bounding_box = wcs_bbox_from_shape(shape)
 
-    # Add a few expected attributes, so they can be monkeypatched as needed
-    simple_wcs_function.get_transform = None
-    simple_wcs_function.backward_transform = None
-    simple_wcs_function.available_frames = []
+    # Mock a simple backward transform
+    def backward_transform(*args, **kwargs):
+        try:
+            nx = len(args[0])
+        except TypeError:
+            nx = 1
+        pix = np.arange(nx)
+        trace = np.ones(nx)
+        return trace, pix
+
+    simple_wcs_function.backward_transform = backward_transform
 
     return simple_wcs_function
 

--- a/jwst/extract_1d/tests/test_extract.py
+++ b/jwst/extract_1d/tests/test_extract.py
@@ -59,7 +59,7 @@ def extract_defaults():
                'spectral_order': 1,
                'src_coeff': None,
                'subtract_background': False,
-               'trace_offset': 0.0,
+               'position_offset': 0.0,
                'trace': None,
                'use_source_posn': False,
                'xstart': 0,
@@ -993,7 +993,7 @@ def test_shift_by_offset_horizontal(extract_defaults):
 
     extract_params = extract_defaults.copy()
     extract_params['dispaxis'] = 1
-    extract_params['trace_offset'] = offset
+    extract_params['position_offset'] = offset
 
     ex.shift_by_offset(offset, extract_params)
     assert extract_params['xstart'] == extract_defaults['xstart']
@@ -1007,7 +1007,7 @@ def test_shift_by_offset_vertical(extract_defaults):
 
     extract_params = extract_defaults.copy()
     extract_params['dispaxis'] = 2
-    extract_params['trace_offset'] = offset
+    extract_params['position_offset'] = offset
 
     ex.shift_by_offset(offset, extract_params)
     assert extract_params['xstart'] == extract_defaults['xstart'] + offset
@@ -1021,7 +1021,7 @@ def test_shift_by_offset_coeff(extract_defaults):
 
     extract_params = extract_defaults.copy()
     extract_params['dispaxis'] = 1
-    extract_params['trace_offset'] = offset
+    extract_params['position_offset'] = offset
     extract_params['src_coeff'] = [[2.5, 1.0], [6.5, 1.0]]
     extract_params['bkg_coeff'] = [[-0.5], [3.0], [6.0], [9.5]]
 
@@ -1036,7 +1036,7 @@ def test_shift_by_offset_trace(extract_defaults):
 
     extract_params = extract_defaults.copy()
     extract_params['dispaxis'] = 1
-    extract_params['trace_offset'] = offset
+    extract_params['position_offset'] = offset
     extract_params['trace'] = np.arange(10, dtype=float)
 
     ex.shift_by_offset(offset, extract_params, update_trace=True)
@@ -1048,7 +1048,7 @@ def test_shift_by_offset_trace_no_update(extract_defaults):
 
     extract_params = extract_defaults.copy()
     extract_params['dispaxis'] = 1
-    extract_params['trace_offset'] = offset
+    extract_params['position_offset'] = offset
     extract_params['trace'] = np.arange(10, dtype=float)
 
     ex.shift_by_offset(offset, extract_params, update_trace=False)
@@ -1209,7 +1209,7 @@ def test_define_aperture_extra_offset(mock_nirspec_fs_one_slit, extract_defaults
     slit = None
     exptype = 'NRS_FIXEDSLIT'
 
-    extract_defaults['trace_offset'] = 2.0
+    extract_defaults['position_offset'] = 2.0
 
     result = ex.define_aperture(model, slit, extract_defaults, exptype)
     _, _, _, profile, _, limits = result
@@ -1511,7 +1511,7 @@ def test_create_extraction_use_trace(
         if aper[i]['id'] == 'S1600A1':
             aper[i]['use_source_posn'] = True
             aper[i]['extract_width'] = extract_width
-            aper[i]['trace_offset'] = 0
+            aper[i]['position_offset'] = 0
 
     # mock the source location function
     def mock_source_location(*args):

--- a/jwst/extract_1d/tests/test_extract.py
+++ b/jwst/extract_1d/tests/test_extract.py
@@ -31,7 +31,7 @@ def extract1d_ref_dict():
                  {'id': 'slit6', 'use_source_posn': True},
                  {'id': 'slit7', 'spectral_order': 20},
                  {'id': 'S200A1'},
-                 {'id': 'S1600A1'}
+                 {'id': 'S1600A1', 'use_source_posn': False}
                  ]
     ref_dict = {'apertures': apertures}
     return ref_dict
@@ -200,13 +200,14 @@ def test_get_extract_parameters_no_match(
 def test_get_extract_parameters_source_posn_exptype(
         mock_nirspec_bots, extract1d_ref_dict, extract_defaults):
     input_model = mock_nirspec_bots
+    input_model.meta.exposure.type = 'NRS_LAMP'
 
     # match a bare entry
     params = ex.get_extract_parameters(
         extract1d_ref_dict, input_model, 'slit1', 1, input_model.meta,
         use_source_posn=None)
 
-    # use_source_posn is switched off for NRS_BRIGHTOBJ
+    # use_source_posn is switched off for unknown exptypes
     assert params['use_source_posn'] is False
 
 
@@ -1464,6 +1465,7 @@ def test_create_extraction_one_int(create_extraction_inputs, mock_nirspec_bots, 
     model = mock_nirspec_bots
     model.data = model.data[0].reshape(1, *model.data.shape[-2:])
     create_extraction_inputs[0] = model
+    create_extraction_inputs[4] = 'S1600A1'
 
     log_watcher.message = '1 integration done'
     ex.create_extraction(
@@ -1476,6 +1478,7 @@ def test_create_extraction_one_int(create_extraction_inputs, mock_nirspec_bots, 
 def test_create_extraction_log_increment(
         create_extraction_inputs, mock_nirspec_bots, log_watcher):
     create_extraction_inputs[0] = mock_nirspec_bots
+    create_extraction_inputs[4] = 'S1600A1'
 
     # all integrations are logged
     log_watcher.message = '... 9 integrations done'

--- a/jwst/extract_1d/tests/test_extract_1d_step.py
+++ b/jwst/extract_1d/tests/test_extract_1d_step.py
@@ -53,7 +53,7 @@ def test_extract_nirspec_mos_multi_slit(mock_nirspec_mos, simple_wcs):
 
 def test_extract_nirspec_bots(mock_nirspec_bots, simple_wcs):
     result = Extract1dStep.call(
-        mock_nirspec_bots, apply_apcorr=False)
+        mock_nirspec_bots, apply_apcorr=False, use_source_posn=False)
     assert result.meta.cal_step.extract_1d == 'COMPLETE'
     assert (result.spec[0].name == 'S1600A1')
 

--- a/jwst/extract_1d/tests/test_extract_1d_step.py
+++ b/jwst/extract_1d/tests/test_extract_1d_step.py
@@ -53,7 +53,7 @@ def test_extract_nirspec_mos_multi_slit(mock_nirspec_mos, simple_wcs):
 
 def test_extract_nirspec_bots(mock_nirspec_bots, simple_wcs):
     result = Extract1dStep.call(
-        mock_nirspec_bots, apply_apcorr=False, use_trace=False)
+        mock_nirspec_bots, apply_apcorr=False)
     assert result.meta.cal_step.extract_1d == 'COMPLETE'
     assert (result.spec[0].name == 'S1600A1')
 

--- a/jwst/regtest/test_nirspec_bots_extract1d.py
+++ b/jwst/regtest/test_nirspec_bots_extract1d.py
@@ -20,6 +20,7 @@ def run_extract(rtdata_module, request):
     # Run the calwebb_spec2 pipeline;
     args = ["extract_1d", rtdata.input,
             f"--override_extract1d={ref_file}",
+            "--use_source_posn=False",
             "--suffix=x1dints"]
     Step.from_cmdline(args)
 


### PR DESCRIPTION
Proposal to expand trace-based extraction to all use_source_posn cases.  

A couple things to note:
- I added a MIRI trace calculation, similar to the NIRSpec one you implemented.
- I added bounding box handling to both trace calculations. This doesn't affect NIRSpec much, but it affects MIRI LRS a lot.
- I kept the trace_offset parameter, but expanded its usage. It can now be used to tweak any aperture definition.
- I removed the use_trace parameter, since it's redundant with use_source_posn.  A trace is now computed anytime a source position is.
- BOTS now defaults to use_source_posn=True.
- Docs will need updating if we like these changes.

Let me know what you think - I'm eager to get something like this in because it folds in nicely with the work we're doing for optimal extraction. In particular, with these changes, I can get the optimal extraction we developed for MIRI LRS working with a toy NIRSpec PSF model very straightforwardly.